### PR TITLE
Modify FaceCaptureController line 327 for Flutter compiler.

### DIFF
--- a/AcuantFaceCapture/AcuantFaceCapture.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AcuantFaceCapture/AcuantFaceCapture.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/AcuantFaceCapture/AcuantFaceCapture/FaceCaptureController.swift
+++ b/AcuantFaceCapture/AcuantFaceCapture/FaceCaptureController.swift
@@ -324,7 +324,7 @@ public class FaceCaptureController: UIViewController {
     }
 
     func createSemiTransparentOverlay() -> UIView {
-        let view = UIView(frame: view.bounds)
+        let view = UIView(frame: self.view.bounds)
         view.backgroundColor = UIColor.black.withAlphaComponent(0.1)
         return view
     }


### PR DESCRIPTION
"let view = UIView(frame: view.bounds)"  Should be replaced by  "let view = UIView(frame: self.view.bounds)"  in  line 327 FaceCaptureController.swift: func createSemiTransparentOverlay() -> UIView

It will be the same for Xcode, but Flutter compile it as error “Variable used within its own initial value”  

```
** BUILD FAILED **
Xcode's output:
↳
    /Library/Couver/CoverApp/couver_app_flutter/ios/Pods/AcuantiOSSDKV11/AcuantFaceCapture/AcuantFaceCapture/FaceCaptureController.swift:327:34: error: variable used within its own initial value
            let view = UIView(frame: view.bounds)
                                     ^

```
Please update this line so it’s possible to run in Flutter.